### PR TITLE
Add a $VROOMDIR environment variable containing the path to $VROOMFILE.

### DIFF
--- a/examples/basics.vroom
+++ b/examples/basics.vroom
@@ -116,6 +116,15 @@ It is local to the directory where vroom is started.
   :echomsg $VROOMFILE
   ~ *basics.vroom (glob)
 
+The relative path to the directory containing $VROOMFILE can be found in the
+$VROOMDIR environment variable.
+
+If vroom was started from the directory containing $VROOMFILE, $VROOMDIR will
+be set to '.', and so a file in the same directory as $VROOMFILE can be named
+using a path such as $VROOMDIR/foo.vim.
+
+  :echomsg $VROOMDIR
+  ~ (\.|(.+/)?examples) (regex)
 
 
 

--- a/vroom/shell.py
+++ b/vroom/shell.py
@@ -1,6 +1,7 @@
 """Vroom fake shell bridge."""
 import json
 import os
+import os.path
 import pickle
 import pipes
 import re
@@ -15,6 +16,7 @@ import vroom.test
 # pylint: disable-msg=nonstandard-exception
 
 VROOMFILE_VAR = 'VROOMFILE'
+VROOMDIR_VAR = 'VROOMDIR'
 LOG_FILENAME_VAR = 'VROOM_SHELL_LOGFILE'
 CONTROL_FILENAME_VAR = 'VROOM_SHELL_CONTROLLFILE'
 ERROR_FILENAME_VAR = 'VROOM_SHELL_ERRORFILE'
@@ -81,6 +83,7 @@ class Communicator(object):
 
     self.env = os.environ.copy()
     self.env[VROOMFILE_VAR] = filename
+    self.env[VROOMDIR_VAR] = os.path.dirname(filename) or '.'
     self.env[vroom.shell.LOG_FILENAME_VAR] = self.log_filename
     self.env[vroom.shell.CONTROL_FILENAME_VAR] = self.control_filename
     self.env[vroom.shell.ERROR_FILENAME_VAR] = self.error_filename


### PR DESCRIPTION
Using `examples/basics.vroom` as an example, $VROOMDIR might return `examples`, `path/to/examples`, or `.` (not the empty string), depending on where vroom was run from.

Fixes #17.
