### PR TITLE
Match E449 ("Invalid expression received") by code, not message text.

### DIFF
--- a/vroom/vim.py
+++ b/vroom/vim.py
@@ -135,8 +135,7 @@ class Communicator(object):
           '--servername', self.args.servername,
           '--remote-expr', expression])
     except ErrorOnExit as e:
-      if (e.error_text ==
-          'E449: Invalid expression received: Send expression failed.'):
+      if e.error_text.startswith('E449:'):  # Invalid expression received
         raise InvalidExpression(expression)
       raise
 


### PR DESCRIPTION
This allows us to recognise this error even when `LANG` is set to something other that `en_US` or `en_GB`.

References #25.
