### PR TITLE
Fix backslash escaping for Neovim

### DIFF
--- a/vroom/neovim_mod.py
+++ b/vroom/neovim_mod.py
@@ -54,9 +54,10 @@ class Communicator(VimCommunicator):
       Quit: If vim quit unexpectedly.
     """
     self.writer.Log(command)
-    cmd = 'call feedkeys("%s")' % command.replace('"', '\\"')
-    cmd = cmd.replace('<', '\<')
-    self.conn.command(cmd)
+    command = command.replace('\\', '\\\\')
+    command = command.replace('"', '\\"')
+    command = command.replace('<', '\\<')
+    self.conn.command('call feedkeys("%s")' % command)
     self._cache = {}
     time.sleep(self.args.delay + extra_delay)
 


### PR DESCRIPTION
- Escape backslashes
- Fix escape for <
- Make the escaping code more clear
- Issue #33
