### PR TITLE
Fix bug that manifests when run in Python 3

### DIFF
--- a/vroom/vim.py
+++ b/vroom/vim.py
@@ -250,7 +250,7 @@ class Communicator(object):
     #
     # Note that this does not affect messages from the vim server process,
     # which should be matched using error codes as usual.
-    env = dict(self.env.items() +
+    env = dict(list(self.env.items()) +
                [['LANGUAGE', 'en_US.UTF-8'], ['LC_ALL', 'en_US.UTF-8']])
 
     out, err = subprocess.Popen(


### PR DESCRIPTION
I just tried out `vroom` for the first time and the first problem I ran into was:

```
$ vroom vroom.vroom
vroom.vroom

ERROR: Traceback (most recent call last):
  File "/Users/myint/Library/Python/3.4/lib/python/site-packages/vroom/runner.py", line 70, in __call__
    self.env.vim.Start()
  File "/Users/myint/Library/Python/3.4/lib/python/site-packages/vroom/vim.py", line 75, in Start
    if not self._IsCurrentDisplayUsable():
  File "/Users/myint/Library/Python/3.4/lib/python/site-packages/vroom/vim.py", line 96, in _IsCurrentDisplayUsable
    self.Ask('1')
  File "/Users/myint/Library/Python/3.4/lib/python/site-packages/vroom/vim.py", line 136, in Ask
    '--remote-expr', expression])
  File "/Users/myint/Library/Python/3.4/lib/python/site-packages/vroom/vim.py", line 254, in TryToSay
    [['LANGUAGE', 'en_US.UTF-8'], ['LC_ALL', 'en_US.UTF-8']])
TypeError: unsupported operand type(s) for +: 'dict_items' and 'list'


Ran 1 test in vroom.vroom. 0 passing, 1 errored, 0 failed.
```
