### PR TITLE
Support macros

### DIFF
--- a/examples/macros.vroom
+++ b/examples/macros.vroom
@@ -1,0 +1,196 @@
+Sometimes you may find yourself repeating similar chunks of vroom code across
+different tests. For example, let's write some tests for the 'cindent' feature:
+
+Enter a small, unindented function
+  % void func()<cr>
+  % {<cr>
+  % if (true) {<cr>
+  % printf("hello\n!");<cr>
+  % }<cr>
+  % }<cr>
+Enable cindent and set tabstop and shiftwidth to 2
+  :set cin ts=2 sw=2 et
+  > gg=G
+Now function should have a 2-space indentation:
+  void func()
+  {
+    if (true) {
+      printf("hello\n!");
+    }
+  }
+  &
+  @end
+  @clear
+
+Now let's test cindent again, but with another value for ts/sw. To make sure
+the previous indentation won't affect this one, we start with a clear buffer:
+  % void func()<cr>
+  % {<cr>
+  % if (true) {<cr>
+  % printf("hello\n!");<cr>
+  % }<cr>
+  % }<cr>
+  :set cin ts=4 sw=4 et
+  > gg=G
+  void func()
+  {
+      if (true) {
+          printf("hello\n!");
+      }
+  }
+  &
+  @end
+  @clear
+
+The above pattern of writing tests can generalized like this:
+
+- Start with a clear buffer
+- Input some text
+- Call a function or command with some parameters
+- Verify if the buffer is in a expected state
+- Repeat but with a different set of parameters
+
+Macros can be used to create reusable chunks of vroom code and help reduce
+boilerplate across tests. Let's rewrite the above test using macros:
+
+  @macro (input_unindented_function)
+  % void func()<cr>
+  % {<cr>
+  % if (true) {<cr>
+  % printf("hello\n!");<cr>
+  % }<cr>
+  % }<cr>
+  @endmacro
+
+The above defined a macro named 'input_unindented_function' that takes care of
+entering an unindented function in the current buffer.
+
+  &
+  @end
+
+As you can see, the buffer wasn't modified. The macro can be "executed" with
+a @do directive:
+
+  @do (input_unindented_function)
+  void func()
+  {
+  if (true) {
+  printf("hello\n!");
+  }
+  }
+  &
+  @end
+
+Now indent and verify output
+  :set cin ts=4 sw=4 et
+  > gg=G
+  void func()
+  {
+      if (true) {
+          printf("hello\n!");
+      }
+  }
+  &
+  @end
+  @clear
+
+A cool thing about macros is that the lines between the @macro/@endmacro
+directives can contain python format string syntax(the same syntax used by
+str.format()). For example:
+
+  @macro (greet)
+  % hello {subject}<cr>
+  @endmacro
+  @do (greet, subject='world')
+  @do (greet, subject='vroom')
+  hello world
+  hello vroom
+  &
+  @end
+  @clear
+
+That means we can generalize even the cindent verification:
+
+  @macro (indent_and_verify)
+  :set cin ts={count} sw={count} et
+  > gg=G
+  void func()
+  {{
+  {fill:{count}}if (true) {{
+  {fill:{count}}{fill:{count}}printf("hello\n!");
+  {fill:{count}}}}
+  }}
+Notice how any braces that are part of the output need to be escaped. This is
+only necessary when the macro is executed with arguments.
+  &
+  @endmacro
+
+Let's split into two macros to improve readability:
+
+  @macro (verify)
+  void func()
+  {{
+  {indent}if (true) {{
+  {indent}{indent}printf("hello\n!");
+  {indent}}}
+  }}
+  &
+  @endmacro
+
+  @macro (indent_and_verify)
+Notice how macros can be redefined at any time
+  :set cin ts={count} sw={count} et
+  > gg=G
+  @do (verify, indent='{fill:{count}}')
+  @endmacro
+
+After the macro is defined we can easily test cindent for multiple ts/sw
+values. The keyword arguments passed to @do can contain simple python
+expressions:
+
+  @do (input_unindented_function)
+  @do (indent_and_verify, fill=' ', count=2)
+  @clear
+  @do (input_unindented_function)
+  @do (indent_and_verify, fill=' ', count=4)
+  @clear
+
+Since macros can contain `@do` directives, the test can be simplified even
+further:
+
+  @macro (test_cindent)
+  @do (input_unindented_function)
+  @do (indent_and_verify, fill=' ', count={width})
+  @clear
+  @endmacro
+
+  @do (test_cindent, width=2)
+  @do (test_cindent, width=4)
+  @do (test_cindent, width=6)
+  @do (test_cindent, width=8)
+
+It's important to understand parsing macro contents is delayed until a
+corresponding @do directive is found:
+
+  @macro (insert_or_verify)
+  {prefix}some text
+  @endmacro
+
+Input the text
+
+  @do (insert_or_verify, prefix='% ')
+  @do (insert_or_verify, prefix='')
+  @clear
+
+Finally, macro names can contain spaces for more descriptive names:
+
+  @macro (test cindent for arbitrary widths)
+  @do (test_cindent, width={width})
+  @endmacro
+
+  @do (test cindent for arbitrary widths, width=2)
+  @do (test cindent for arbitrary widths, width=4)
+  @do (test cindent for arbitrary widths, width=8)
+
+For more details about python format syntax, see:
+https://docs.python.org/2/library/string.html#format-string-syntax

--- a/vroom/actions.py
+++ b/vroom/actions.py
@@ -1,3 +1,5 @@
+import collections
+
 """Vroom action parsing (actions are different types of vroom lines)."""
 import vroom
 import vroom.controls
@@ -13,15 +15,20 @@ ACTION = vroom.Specification(
     MESSAGE='message',
     SYSTEM='system',
     HIJACK='hijack',
-    OUTPUT='output')
+    OUTPUT='output',
+    MACRO='macro')
 
 DIRECTIVE = vroom.Specification(
     CLEAR='clear',
     END='end',
     MESSAGES='messages',
-    SYSTEM='system')
+    SYSTEM='system',
+    MACRO='macro',
+    ENDMACRO='endmacro',
+    DO='do')
 
 DIRECTIVE_PREFIX = '  @'
+ENDMACRO = DIRECTIVE_PREFIX + DIRECTIVE.ENDMACRO
 EMPTY_LINE_CHECK = '  &'
 
 # The number of blank lines that equate to a @clear command.
@@ -53,7 +60,7 @@ CONTROLLED_LINE_TYPES = {
 }
 
 
-def ActionLine(line):
+def ActionLine(line, state=None):
   """Parses a single action line of a vroom file.
 
   >>> ActionLine('This is a comment.')
@@ -80,6 +87,30 @@ def ActionLine(line):
   Traceback (most recent call last):
     ...
   ParseError: Unrecognized directive "nope"
+  >>> state = ParseState([])
+  >>> ActionLine('  @macro (abc)', state)
+  ('macro', None, None)
+  >>> state.lineno += 1 # need to update the state lineno
+  >>> ActionLine('  > iHello, world!<ESC> (2s)', state)
+  ('macro', None, None)
+  >>> state.lineno += 1
+  >>> ActionLine('  :wqa', state)
+  ('macro', None, None)
+  >>> state.lineno += 1
+  >>> ActionLine('  % Hello, world!', state)
+  ('macro', None, None)
+  >>> ActionLine('  @endmacro', state)
+  ('macro', None, None)
+  >>> state.lines
+  deque([])
+  >>> ActionLine('  @do (abc)', state)
+  ('macro', None, None)
+  >>> state.NextLine() # macro lines are added to the front of the queue
+  ('  > iHello, world!<ESC> (2s)', 0)
+  >>> state.NextLine()
+  ('  :wqa', 1)
+  >>> state.NextLine()
+  ('  % Hello, world!', 2)
   >>> ActionLine('  & Output!')  # doctest: +ELLIPSIS
   ('output', 'Output!', ...)
   >>> ActionLine('  Simpler output!')  # doctest: +ELLIPSIS
@@ -87,6 +118,7 @@ def ActionLine(line):
 
   Args:
     line: The line (string)
+    state(ParseState): An object keeping track of parse state
   Returns:
     (ACTION, line, controls) where line is the original line with the newline,
         action prefix ('  > ', etc.) and control block removed, and controls is
@@ -94,6 +126,14 @@ def ActionLine(line):
   Raises:
     vroom.ParseError
   """
+
+  # If a macro is currently being recorded, then we must lookahead for the
+  # @endmacro directive or else it would be included in the macro which is not
+  # what we want
+  if state and state.macro_name and not line.startswith(ENDMACRO):
+    state.macros[state.macro_name].append((line, state.lineno))
+    return (ACTION.MACRO, None, None)
+
   line = line.rstrip('\n')
 
   # PASS is different from COMMENT in that PASS breaks up output blocks,
@@ -138,6 +178,25 @@ def ActionLine(line):
     elif directive == DIRECTIVE.SYSTEM:
       return (ACTION.DIRECTIVE, directive, Controls(
           (vroom.controls.OPTION.SYSTEM_STRICTNESS,)))
+    elif directive == DIRECTIVE.MACRO:
+      if state.macro_name:
+        raise vroom.ParseError("Nested macro definitions aren't allowed")
+      state.macro_name = controls
+      state.macro_lineno = state.lineno
+      state.macros[state.macro_name] = []
+      return (ACTION.MACRO, None, None)
+    elif directive == DIRECTIVE.ENDMACRO:
+      if not state.macro_name:
+        raise vroom.ParseError('Not defining a macro')
+      state.macros[state.macro_name] = Macro(state.macros[state.macro_name])
+      state.macro_name = None
+      return (ACTION.MACRO, None, None)
+    elif directive == DIRECTIVE.DO:
+      name, kwargs = Macro.ParseCall(controls)
+      if name not in state.macros:
+        raise vroom.ParseError('Macro "%s" is not defined' % name)
+      state.lines.extendleft(state.macros[name].Expand(kwargs))
+      return (ACTION.MACRO, None, None)
     # Non-controlled directives should be parsed before SplitLineControls.
     raise vroom.ParseError('Unrecognized directive "%s"' % directive)
 
@@ -173,14 +232,22 @@ def Parse(lines):
   """
   pending = None
   pass_count = 0
-  for (lineno, line) in enumerate(lines):
+  state = ParseState(lines)
+
+  while state.lines:
+    line, lineno = state.NextLine()
+    # ensure the state lineno always matches the real lineno(so it is restored
+    # after a @do directive
+    state.lineno = lineno
     try:
-      (linetype, line, control) = ActionLine(line)
+      (linetype, line, control) = ActionLine(line, state)
     # Add line number context to all parse errors.
     except vroom.ParseError as e:
       e.SetLineNumber(lineno)
       raise
     # Ignore comments during vroom execution.
+    if linetype == ACTION.MACRO:
+      continue
     if linetype == ACTION.COMMENT:
       # Comments break blank-line combos.
       pass_count = 0
@@ -217,3 +284,64 @@ def Parse(lines):
   # Flush out any actions still in the queue.
   if pending:
     yield pending
+  if state.macro_name:
+    e = vroom.ParseError('Unfinished macro "%s"' % state.macro_name)
+    e.SetLineNumber(state.macro_lineno)
+    raise e
+
+
+class ParseState(object):
+  def __init__(self, lines):
+    self.macro_name = None
+    self.macros = {}
+    self.lineno = -1
+    self.lines = collections.deque(
+      (line, lineno) for lineno, line in enumerate(lines))
+
+  def NextLine(self):
+    self.lineno += 1
+    return self.lines.popleft()
+
+
+class Macro(object):
+  def __init__(self, lines):
+    # The lines are need to be reversed so the order will be kept when
+    # concatenating with deque.extendleft, which is the same as:
+    # for item in list: deque.appendleft(item).
+    self.lines = list(reversed(lines))
+
+  def Expand(self, kwargs):
+    for line in self.lines:
+      if kwargs:
+        yield (line[0].format(**kwargs), line[1])
+      else:
+        yield line
+
+  @classmethod
+  def ParseCall(self, controls):
+    """Parses the control section of a @do directive
+
+    >>> name, kwargs = Macro.ParseCall("name, a=1,b=2,c='3'")
+    >>> name
+    'name'
+    >>> kwargs['a']
+    1
+    >>> kwargs['b']
+    2
+    >>> kwargs['c']
+    '3'
+
+    Args:
+      controls: The controls string
+    Returns:
+      (name, kwargs) where name is the macro name and kwargs is a dict with
+                     the keyword arguments passed to str.format
+    """
+    parts = controls.split(',')
+    name = parts[0].strip()
+    kwargs = {}
+    for kv in parts[1:]:
+      k, v = kv.split('=')
+      kwargs[k.strip()] = eval(v)
+    return name, kwargs
+

--- a/vroom/controls.py
+++ b/vroom/controls.py
@@ -29,7 +29,7 @@ REGEX = vroom.Specification(
     RANGE=re.compile(r'^(\.|\d+)?(?:,(\+)?(\$|\d+)?)?$'),
     MODE=re.compile(r'^(%s)$' % '|'.join(MODE.Values())),
     DELAY=re.compile(r'^(\d+(?:\.\d+)?)s?$'),
-    CONTROL_BLOCK=re.compile(r'(  .*) \(\s*([\w\d.+,$ ]*)\s*\)$'),
+    CONTROL_BLOCK=re.compile(r'(  .*) \(\s*([%><=\'"\w\d.+,$ ]*)\s*\)$'),
     ESCAPED_BLOCK=re.compile(r'(  .*) \(&([^)]+)\)$'))
 
 DEFAULT_MODE = MODE.VERBATIM


### PR DESCRIPTION
This adds three directives:
- `@macro (name)`: Starts recording a macro identified by 'name'
- `@endmacro`: Stops recording a macro
- `@do (name, kwargs)`: "Execute" the macro identified by 'name' by replacing the
  directive by the recorded macro contents, using kwargs to format the lines
