### PR TITLE
Update neovim_mod to use NVIM_LISTEN_ADDRESS env var

### DIFF
--- a/vroom/neovim_mod.py
+++ b/vroom/neovim_mod.py
@@ -20,7 +20,7 @@ class Communicator(VimCommunicator):
         '-u', args.vimrc,
         '-c', 'set shell=' + args.shell,
         '-c', 'source %s' % CONFIGFILE]
-    env['NEOVIM_LISTEN_ADDRESS'] = args.servername
+    env['NVIM_LISTEN_ADDRESS'] = args.servername
     self.env = env
     self._cache = {}
 


### PR DESCRIPTION
Neovim will now use NVIM_LISTEN_ADDRESS instead of NEOVIM_LISTEN_ADDRESS
