### PR TITLE
Add some necessary decodes() to neovim_mod

### DIFF
--- a/vroom/neovim_mod.py
+++ b/vroom/neovim_mod.py
@@ -69,7 +69,7 @@ class Communicator(VimCommunicator):
     Raises:
       Quit: If vim quit unexpectedly.
     """
-    return self.conn.eval(expression)
+    return self.conn.eval(expression).decode('utf-8')
 
   def GetBufferLines(self, number):
     """Gets the lines in the requested buffer.
@@ -94,7 +94,7 @@ class Communicator(VimCommunicator):
       linecount = buf.get_length()
       lines = []
       for i in range(linecount):
-        lines.append(buf.get_line(i))
+        lines.append(buf.get_line(i).decode('utf-8'))
       self._cache[number] = lines
     return self._cache[number]
 


### PR DESCRIPTION
This commit updates the neovim module to work with python3 by adding
some calls to .decode('utf-8'). These calls are necessary because in
python3, the communications interface uses bytes() objects internally
unlike the strs used in previous versions.
