### PR TITLE
Support Neovim commands in shell.vroomfaker

### DIFF
--- a/scripts/shell.vroomfaker
+++ b/scripts/shell.vroomfaker
@@ -40,8 +40,12 @@ try:
   with open(controlfile, 'rb') as f:
     controls = pickle.load(f)
 
-  # Parse the user command out from vim's gibberish.
-  command, rebuild = vroom.vim.SplitCommand(sys.argv[2])
+  if os.getenv('VROOM_NEOVIM'):
+    # Neovim does not wrap commands, just pass then unchanged
+    command, rebuild = (sys.argv[2], lambda cmd: cmd)
+  else:
+    # Parse the user command out from vim's gibberish.
+    command, rebuild = vroom.vim.SplitCommand(sys.argv[2])
   logs.append(vroom.test.Received(command))
   handled = False
 

--- a/vroom/neovim_mod.py
+++ b/vroom/neovim_mod.py
@@ -21,6 +21,8 @@ class Communicator(VimCommunicator):
         '-c', 'set shell=' + args.shell,
         '-c', 'source %s' % CONFIGFILE]
     env['NVIM_LISTEN_ADDRESS'] = args.servername
+    # Set environment for shell.vroomfaker to know Neovim is being used
+    env['VROOM_NEOVIM'] = '1'
     self.env = env
     self._cache = {}
 


### PR DESCRIPTION
- Following #60
- Disable shell.vroomfaker command parsing when running Neovim
- When Vim calls the shell to run a command it wraps the command and
  redirects the output to a temporary file. When intercepting calls
  shell.vroomfaker removes the wrapping in order to match the command.
  However Neovim differs from Vim and passes the command to the shell
  unaltered.
- When running Neovim Vroom sets an environment variable VROOM_NEOVIM
  that causes shell.vroomfaker to disable the command parsing used for
  Vim
