### PR TITLE
Fix py3 compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
+/MANIFEST
 /build/
 /deb_dist/
+/dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [sdist_dsc]
 package = vroom
+package3 = vroom

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 """Distribution for vroom."""
+import codecs
 from distutils.core import setup
 import os.path
 
-with open(os.path.join(os.path.dirname(__file__), 'vroom/VERSION.txt')) as f:
+version_path = os.path.join(os.path.dirname(__file__), 'vroom/VERSION.txt')
+with codecs.open(version_path, 'r', 'utf-8') as f:
   version = f.read().strip()
 
 setup(

--- a/vroom/__init__.py
+++ b/vroom/__init__.py
@@ -3,7 +3,7 @@
 
 def __read_version_txt():
   import pkgutil
-  return pkgutil.get_data('vroom', 'VERSION.txt').strip()
+  return pkgutil.get_data('vroom', 'VERSION.txt').decode('utf-8').strip()
 
 __version__ = __read_version_txt()
 

--- a/vroom/vim.py
+++ b/vroom/vim.py
@@ -250,8 +250,10 @@ class Communicator(object):
     #
     # Note that this does not affect messages from the vim server process,
     # which should be matched using error codes as usual.
-    env = dict(self.env.items() +
-               [['LANGUAGE', 'en_US.UTF-8'], ['LC_ALL', 'en_US.UTF-8']])
+    env = self.env.copy()
+    env.update({
+      'LANGUAGE': 'en_US.UTF-8',
+      'LC_ALL': 'en_US.UTF-8'})
 
     out, err = subprocess.Popen(
         cmd,


### PR DESCRIPTION
Fix errors that made vroom unusable under python3.

@Soares maintained python3 compatibility originally, but a few recent changes introduced compatibility problems.
