### PR TITLE
Add .travis.yml file to run vroom on ./examples/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+install:
+  - python setup.py -q install
+before_script:
+  - sudo apt-get install vim-gnome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+script:
+  - vroom --crawl ./examples/


### PR DESCRIPTION
Sets up Travis CI to ensure that vroom files in examples/ pass.

This is just integration-level testing. Vroom should still have python tests (#63).

Doesn't run in neovim mode yet (#64).
