### PR TITLE
Travis CI: Also run examples/ in neovim mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
+before_install:
+  - pip install neovim
 install:
   - python setup.py -q install
 before_script:
-  - sudo apt-get install vim-gnome
+  - sudo add-apt-repository ppa:rudenko/neovim -y
+  - sudo apt-get update -q
+  - sudo apt-get install vim-gnome neovim
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
+  - vroom --crawl --neovim ./examples/
   - vroom --crawl ./examples/


### PR DESCRIPTION
This sets up neovim and runs the vroom examples under neovim mode to ensure we don't completely break neovim mode.

Fixes #64.
