### PR TITLE
Drop py2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
 install:
   - python setup.py -q install

--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ page for some strategies for getting the most out of vroom.
 
 The easiest way to install vroom is to cd into the vroom directory and run
 ```sh
-python setup.py build && sudo python setup.py install
+python3 setup.py build && sudo python3 setup.py install
 ```
 
-Vim syntax files for vroom can be found [here](https://github.com/google/vim-ft.vroom).
+You can also install
+[release packages](https://github.com/google/vroom/releases) from github. To
+build deb packages yourself, make sure you have a recent stdeb version with
+python 3 support installed.
+
+Vim 7.4.384 and later have built-in syntax support for the vroom filetype. You
+can install the standalone
+[ft-vroom plugin](https://github.com/google/vim-ft-vroom) for older versions of
+vim.
 
 ## Known issues
 

--- a/scripts/respond.vroomfaker
+++ b/scripts/respond.vroomfaker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 A special program which fakes a shell script.
 Given a json specification containing any/all of:

--- a/scripts/shell.vroomfaker
+++ b/scripts/shell.vroomfaker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A fake shell, used by vroom to capture and control vim system calls.
 
 This executable is run once per shell command, and thus must do all of its

--- a/scripts/vroom
+++ b/scripts/vroom
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,14 @@
 import codecs
 from distutils.core import setup
 import os.path
+import sys
+
+
+# Don't even try to run under python 2 or earlier. It will seem to work but fail
+# in corner cases with strange encoding errors.
+if sys.version_info[0] < 3:
+  sys.exit('ERROR: Python < 3 is unsupported.')
+
 
 version_path = os.path.join(os.path.dirname(__file__), 'vroom/VERSION.txt')
 with codecs.open(version_path, 'r', 'utf-8') as f:
@@ -21,4 +29,8 @@ setup(
         'scripts/vroom',
     ],
     package_data={'vroom': ['VERSION.txt']},
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+    ],
 )

--- a/vroom/__init__.py
+++ b/vroom/__init__.py
@@ -1,4 +1,11 @@
 """Patterns common to all vroom components."""
+import sys
+
+
+# Don't even try to run under python 2 or earlier. It will seem to work but fail
+# in corner cases with strange encoding errors.
+if sys.version_info[0] < 3:
+  raise ImportError('Python < 3 is unsupported')
 
 
 def __read_version_txt():


### PR DESCRIPTION
Drop support for running vroom under python 2. Adds some (slightly hacky) errors when trying to run or build under python < 3 to avoid more bug reports for py2-only bugs.

Implements #67 and fixes #28 and #59 (by completely disabling for affected python versions).
