### PR TITLE
Add a note about requiring +clientserver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ page for some strategies for getting the most out of vroom.
 
 ## Installation
 
+Note that Vroom requires a version of vim built with the `+clientserver`
+option (run `vim --version` to check).  See `:help clientserver` for
+additional requirements.
+
 The easiest way to install vroom is to cd into the vroom directory and run
 ```sh
 python3 setup.py build && sudo python3 setup.py install


### PR DESCRIPTION
We depend upon `--servername`, which requires `+clientserver`.

Actually using the client/server support requires other dependencies (such as a working X `$DISPLAY` or xterm-clipboard support), so point at `:help clientserver` too.