### PR TITLE
add a result type

### DIFF
--- a/vroom/command.py
+++ b/vroom/command.py
@@ -48,7 +48,7 @@ class Command(object):
   def Execute(self):
     """Executes the command and verifies all checks."""
     if not any((self.command, self._mexpectations, self._syspectations)):
-      return Result.Result(True)
+      return Result.Success()
 
     self.env.shell.Control(self._syspectations)
     oldmessages = self.env.vim.GetMessages()
@@ -76,4 +76,4 @@ class Command(object):
     if failures:
       return Result.Error(vroom.test.Failures(failures))
     else:
-      return Result.Result(True)
+      return Result.Success()

--- a/vroom/command.py
+++ b/vroom/command.py
@@ -14,6 +14,7 @@ the checks and responses attached to it.
 """
 import vroom.test
 
+from vroom.result import Result
 
 class Command(object):
   """Holds a vim command and records all checks requiring verification."""
@@ -47,7 +48,8 @@ class Command(object):
   def Execute(self):
     """Executes the command and verifies all checks."""
     if not any((self.command, self._mexpectations, self._syspectations)):
-      return
+      return Result.Result(True)
+
     self.env.shell.Control(self._syspectations)
     oldmessages = self.env.vim.GetMessages()
     if self.lineno:
@@ -61,21 +63,17 @@ class Command(object):
     failures = []
     # Verify the message list.
     newmessages = self.env.vim.GetMessages()
-    try:
-      self.env.messenger.Verify(oldmessages, newmessages, self._mexpectations)
-    # Don't worry, pylint. The exception will be re-raised. We need to make sure
-    # that we catch code errors as well as test failures here. We don't catch
-    # BaseException, so the program can still quit if it needs to.
-    # pylint: disable-msg=broad-except
-    except Exception as failure:
-      failures.append(failure)
+    result = self.env.messenger.Verify(
+        oldmessages, newmessages, self._mexpectations)
+    if result.IsError():
+      failures.append(result.value)
+
     # Verify the shell.
-    try:
-      self.env.shell.Verify()
-    # See above.
-    # pylint: disable-msg=broad-except
-    except Exception as failure:
-      failures.append(failure)
-    # Wrap the list of failures in vroom.test.Failures and raise.
+    result = self.env.shell.Verify()
+    if result.IsError():
+      failures.append(result.value)
+
     if failures:
-      raise vroom.test.Failures(failures)
+      return Result.Error(vroom.test.Failures(failures))
+    else:
+      return Result.Result(True)

--- a/vroom/messages.py
+++ b/vroom/messages.py
@@ -6,6 +6,8 @@ import vroom
 import vroom.controls
 import vroom.test
 
+from vroom.result import Result
+
 # Pylint is not smart enough to notice that all the exceptions here inherit from
 # vroom.test.Failure, which is a standard Exception.
 # pylint: disable-msg=nonstandard-exception
@@ -83,8 +85,10 @@ class Messenger(object):
       old: What the messages were before the command.
       new: What the messages were after the command.
       expectations: What the command was supposed to message about.
-    Raises:
-      vroom.test.Failures: If an message-related failures were detected.
+    Returns:
+      Result.Error(vroom.test.Failures[MessageFailure]):
+          If any message-related failures were detected.
+      Result.Result(True): Otherwise
     """
     if StartsWithBuiltinMessages(old) and StartsWithBuiltinMessages(new):
       old = StripBuiltinMessages(old)
@@ -125,7 +129,9 @@ class Messenger(object):
         failures.append(e)
 
     if failures:
-      raise vroom.test.Failures(failures)
+      return Result.Error(vroom.test.Failures(failures))
+    else:
+      return Result.Result(True)
 
   def Unexpected(self, message, new):
     """Handles an unexpected message."""

--- a/vroom/messages.py
+++ b/vroom/messages.py
@@ -88,7 +88,7 @@ class Messenger(object):
     Returns:
       Result.Error(vroom.test.Failures[MessageFailure]):
           If any message-related failures were detected.
-      Result.Result(True): Otherwise
+      Result.Success(): Otherwise
     """
     if StartsWithBuiltinMessages(old) and StartsWithBuiltinMessages(new):
       old = StripBuiltinMessages(old)
@@ -131,7 +131,7 @@ class Messenger(object):
     if failures:
       return Result.Error(vroom.test.Failures(failures))
     else:
-      return Result.Result(True)
+      return Result.Success()
 
   def Unexpected(self, message, new):
     """Handles an unexpected message."""

--- a/vroom/result.py
+++ b/vroom/result.py
@@ -1,0 +1,31 @@
+"""Result type."""
+
+from collections import namedtuple
+from enum import Enum
+
+class ResultType(Enum):
+  result = 1
+  error = 2
+
+# Inherit from namedtuple so we get an immutable value.
+class Result(namedtuple('Result', ['status', 'value'])):
+  """Holds the result or error of a function call.
+
+  status should be one of ResultType.result or ResultType.error
+  """
+
+  @classmethod
+  def Result(cls, value):
+    return super(Result, cls).__new__(cls, status = ResultType.result, value = value)
+
+  @classmethod
+  def Error(cls, value):
+    return super(Result, cls).__new__(cls, status = ResultType.error, value = value)
+
+  def IsError(self):
+    return self.status is ResultType.error
+
+  def IsSignificant(self):
+    if self.status is ResultType.result:
+      return False
+    return self.value.IsSignificant()

--- a/vroom/result.py
+++ b/vroom/result.py
@@ -22,6 +22,11 @@ class Result(namedtuple('Result', ['status', 'value'])):
   def Error(cls, value):
     return super(Result, cls).__new__(cls, status = ResultType.error, value = value)
 
+  @classmethod
+  def Success(cls):
+    """Used to indicate success when the actual value is irrelevant."""
+    return super(Result, cls).__new__(cls, status = ResultType.result, value = True)
+
   def IsError(self):
     return self.status is ResultType.error
 

--- a/vroom/runner.py
+++ b/vroom/runner.py
@@ -12,6 +12,8 @@ import vroom.shell
 import vroom.test
 import vroom.vim
 
+from vroom.result import Result
+
 # Pylint is not smart enough to notice that all the exceptions here inherit from
 # vroom.test.Failure, which is a standard Exception.
 # pylint: disable-msg=nonstandard-exception
@@ -53,11 +55,9 @@ class Vroom(object):
       return
     self.env.buffer.Unload()
     for self._running_command in self._command_queue:
-      try:
-        self._running_command.Execute()
-      except vroom.test.Failure as e:
-        if e.IsSignificant():
-          raise
+      result = self._running_command.Execute()
+      if result.IsError() and result.value.IsSignificant():
+          raise result.value
     self.ResetCommands()
 
   def __call__(self, filehandle):

--- a/vroom/shell.py
+++ b/vroom/shell.py
@@ -103,7 +103,7 @@ class Communicator(object):
     Returns:
       Result.Error(vroom.test.Failures[FakeShellFailure]):
           If any shell failures were detected.
-      Result.Result(True): Otherwise.
+      Result.Success(): Otherwise.
     Raises:
       FakeShellNotWorking: If it can't load the shell file.
     """
@@ -141,7 +141,7 @@ class Communicator(object):
     if failures:
       return Result.Error(vroom.test.Failures(failures))
     else:
-      return Result.Result(True)
+      return Result.Success()
 
 
 class Hijack(object):

--- a/vroom/shell.py
+++ b/vroom/shell.py
@@ -11,6 +11,8 @@ import vroom
 import vroom.controls
 import vroom.test
 
+from vroom.result import Result
+
 # Pylint is not smart enough to notice that all the exceptions here inherit from
 # vroom.test.Failure, which is a standard Exception.
 # pylint: disable-msg=nonstandard-exception
@@ -98,9 +100,12 @@ class Communicator(object):
   def Verify(self):
     """Checks that system output was caught and handled satisfactorily.
 
+    Returns:
+      Result.Error(vroom.test.Failures[FakeShellFailure]):
+          If any shell failures were detected.
+      Result.Result(True): Otherwise.
     Raises:
       FakeShellNotWorking: If it can't load the shell file.
-      vroom.test.Failures: If there are other failures.
     """
     # Copy any new logs into the logger.
     logs = Load(self.log_filename)
@@ -134,7 +139,9 @@ class Communicator(object):
         failures.append(UnexpectedSystemCalls(logs, commands_logs))
 
     if failures:
-      raise vroom.test.Failures(failures)
+      return Result.Error(vroom.test.Failures(failures))
+    else:
+      return Result.Result(True)
 
 
 class Hijack(object):


### PR DESCRIPTION
A very simple implementation of a result type that wraps and returns exceptions from Message and Shell rather than reraising them. Tested manually by introducing errors to the example/* files and making sure the vroom output didn't change.

I believe this fixes all instances of reraising other than in the main Run loop.