### PR TITLE
Start xvfb using 'services' rather than a run script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,11 @@ before_install:
 install:
   - python setup.py -q install
 before_script:
-  - if [ $CI_TARGET = vim ]; then
-      export DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-    elif [ $CI_TARGET = neovim ]; then
+  - if [ $CI_TARGET = neovim ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64";
     fi
+services:
+  - xvfb
 script:
   - if [ $CI_TARGET = pytests ]; then
       nosetests -v --with-doctest;


### PR DESCRIPTION
This is necessary now that Travis has switched from Trusty to Xenial by default.

(See https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services)