### PR TITLE
Fix weirdly duplicated system hijack output on python 3.7

### DIFF
--- a/vroom/shell.py
+++ b/vroom/shell.py
@@ -202,7 +202,7 @@ class Hijack(object):
       except re.error as e:
         raise vroom.ParseError("Can't match command. Invalid regex. %s'" % e)
     else:
-      match_regex = re.compile(r'.*')
+      match_regex = re.compile(r'^.*$')
 
     # The actual response won't be exactly like the internal response, because
     # we've got to do some regex group binding magic.


### PR DESCRIPTION
An intentional behavior change in python re.sub added a second empty
match and "substitution" for '.*' (https://bugs.python.org/issue32308).
This changed the catch-all regex vroom was using to an anchored '^.*$',
which will ensure it only makes one substitution.

Fixes #110.