### PR TITLE
Fix errors for undefined constants like colors.GREEN in non-ANSI terms

### DIFF
--- a/vroom/color.py
+++ b/vroom/color.py
@@ -15,6 +15,19 @@ try:
   RESET = subprocess.check_output(['tput', 'sgr0']).decode('utf-8')
 except subprocess.CalledProcessError:
   COLORED = False
+  # Placeholders for code that tries to map things onto terminal colors.
+  # These will be unused anyway if COLORED=False, and empty string would be
+  # "no-op" color code for any code that did end up using these values.
+  BOLD = ''
+  RED = ''
+  GREEN = ''
+  YELLOW = ''
+  BLUE = ''
+  VIOLET = ''
+  TEAL = ''
+  WHITE = ''
+  BLACK = ''
+  RESET = ''
 else:
   COLORED = True
 


### PR DESCRIPTION
Resolves the issue that color constants were conditionally defined but
unconditionally referenced, causing AttributeErrors on any invocation
that falls back to COLORED=False. Defines constants with no-op color
code values so they can still be referenced without cluttering up all
the referencing code with conditionals.

Fixes #112.