### PR TITLE
Improve shell errors handling

### DIFF
--- a/vroom/buffer.py
+++ b/vroom/buffer.py
@@ -65,7 +65,7 @@ class Manager(object):
     # No need to decrement; vroom ranges are inclusive and vim 1-indexes.
     end = (start + 1) if end is None else end(start + 1)
     # End = 0 means check till end of buffer.
-    end = len(self._data) if end is 0 else end
+    end = len(self._data) if end == 0 else end
     # If there's an error, they'll want to know what we were looking at.
     self._last_range = (start, end)
 

--- a/vroom/shell.py
+++ b/vroom/shell.py
@@ -285,7 +285,7 @@ class Hijack(object):
     return out.rstrip('\n')
 
 
-class FakeShellNotWorking(Exception):
+class FakeShellNotWorking(vroom.test.Failure):
   """Called when the fake shell is not working."""
 
   def __init__(self, errors):
@@ -293,7 +293,8 @@ class FakeShellNotWorking(Exception):
     super(FakeShellNotWorking, self).__init__()
 
   def __str__(self):
-    return 'The fake shell is not working as anticipated.'
+    errors_description = '\n'.join(list(map(str, self.shell_errors)))
+    return 'The fake shell is not working as anticipated:\n' + errors_description
 
 
 class FakeShellFailure(vroom.test.Failure):


### PR DESCRIPTION
Make sure FakeShellNotWorking is treated as any other Vroom failure and that its string representation contains enough debugging information.